### PR TITLE
Changed default sign out to get

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -266,7 +266,8 @@ Devise.setup do |config|
   # config.navigational_formats = ['*/*', :html]
 
   # The default HTTP method used to sign out a resource. Default is :delete.
-  config.sign_out_via = :delete
+  config.sign_out_via = :get
+  # config.sign_out_via = :delete
 
   # ==> OmniAuth
   # Add a new OmniAuth provider. Check the wiki for more information on setting


### PR DESCRIPTION
There was an issue where we didnt have a get page to sign out.. dont know when this started

This PR changes the devise middleware to recognise a get request to the destroy action