### PR TITLE
Cause relationship validations

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -3,25 +3,26 @@
 class Ability
   include CanCan::Ability
   UNRESTRICTED_MODEL_LIST = [
-    CampaignAction,
     Article,
     BlogArticle,
     BlogComment,
-    CampaignGoal,
     Campaign,
-    Goal,
+    Cause,
+    CampaignAction,
+    CampaignGoal,
     Faq,
+    Goal,
     LearningResource,
     LearningTopic,
-    Notification,
     Offer,
     Organisation,
-    Partnership
+    Partnership,
+    Notification,
   ]
 
   MODEL_LIST = [
     Admin,
-    User
+    User,
   ] + UNRESTRICTED_MODEL_LIST
 
   def initialize(admin)

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -49,4 +49,22 @@ RailsAdmin.config do |config|
       required true
     end
   end
+
+  config.model 'CampaignAction' do
+    fields.each do |f|
+      field f.name
+    end
+    field :causes do
+      required true
+    end
+  end
+
+  config.model 'LearningResource' do
+    fields.each do |f|
+      field f.name
+    end
+    field :causes do
+      required true
+    end
+  end
 end

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -42,30 +42,9 @@ RailsAdmin.config do |config|
   end
 
   config.model 'Campaign' do
-    field :title
-    field :description_app
-    field :header_image
-    field :video_link
-    field :description_web
-    field :enabled
-    field :start_date
-    field :end_date
-    field :short_name
-    field :infographic_url
-    field :of_the_month
-    field :recommended
-    field :status
-    field :campaign_actions
-    field :blog_articles
-    field :articles
-    field :offers
-    field :partnerships
-    field :learning_topics
-    field :organisations
-    field :campaign_goals
-    field :goals
-    field :user_campaigns
-    field :cause_campaigns
+    fields.each do |f|
+      field f.name
+    end
     field :causes do
       required true
     end

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -40,4 +40,34 @@ RailsAdmin.config do |config|
     # history_index
     # history_show
   end
+
+  config.model 'Campaign' do
+    field :title
+    field :description_app
+    field :header_image
+    field :video_link
+    field :description_web
+    field :enabled
+    field :start_date
+    field :end_date
+    field :short_name
+    field :infographic_url
+    field :of_the_month
+    field :recommended
+    field :status
+    field :campaign_actions
+    field :blog_articles
+    field :articles
+    field :offers
+    field :partnerships
+    field :learning_topics
+    field :organisations
+    field :campaign_goals
+    field :goals
+    field :user_campaigns
+    field :cause_campaigns
+    field :causes do
+      required true
+    end
+  end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -4,18 +4,18 @@ require 'database_cleaner'
 
 DatabaseCleaner.clean_with(:truncation)
 
+FactoryBot.create_list(:article, 10)
+FactoryBot.create_list(:blog_article, 10)
 FactoryBot.create_list(:cause, 10)
 FactoryBot.create_list(:campaign, 10)
-FactoryBot.create_list(:goal, 10)
 FactoryBot.create_list(:campaign_action, 10)
-FactoryBot.create_list(:user_action, 10)
-FactoryBot.create_list(:article, 10)
-FactoryBot.create_list(:press_coverage_article, 10)
+FactoryBot.create_list(:goal, 10)
 FactoryBot.create_list(:image_section, 10)
-FactoryBot.create_list(:text_section, 10)
 FactoryBot.create_list(:organisation, 10)
+FactoryBot.create_list(:press_coverage_article, 10)
 FactoryBot.create_list(:partnership, 10)
-FactoryBot.create_list(:blog_article, 10)
+FactoryBot.create_list(:text_section, 10)
+FactoryBot.create_list(:user_action, 10)
 FactoryBot.create_list(:user, 10)
 
 puts "Seeding finished."


### PR DESCRIPTION
We want to ensure that for the following: 

- `Campaign`
- `CampaignAction`
- `LearningResource`

models cannot get created without *at least* one cause attached to the record