### PR TITLE
Rescue invalid filter error to show 501 instead of 200 ok

### DIFF
--- a/app/controllers/api_application_controller.rb
+++ b/app/controllers/api_application_controller.rb
@@ -42,6 +42,6 @@ class APIApplicationController < ActionController::API
   end
 
   def invalid_filter_message(exception)
-    render json: { data: exception }
+    render json: { data: exception }, status: 501
   end
 end


### PR DESCRIPTION
If theres an invalid filter, we caught the exception and raised a custom error message. This error message had a code 200. It should be 501, which its now been changed to. 