### PR TITLE
Update sentry to use stage for environment

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,7 +1,7 @@
 Sentry.init do |config|
   config.dsn = ENV['SENTRY_DSN']
 
-  config.environment = Rails.env
+  config.environment = ENV['STAGE'] 
   config.breadcrumbs_logger = [:sentry_logger, :http_logger]
 
   config.traces_sample_rate = 0.01


### PR DESCRIPTION
Im a bit spooked using rails-env as the environment for sentry as I would rather staging and prod were running in exactly the same mode. I've added an extra env variable so we can know which stage an event is coming from. If this is crazy please let me know