### PR TITLE
Add pagination to endpoints

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ gem 'sentry-ruby'
 gem 'sentry-rails'
 gem 'jwt'
 gem 'meilisearch-rails'
+gem 'pagy'
 
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -216,6 +216,7 @@ GEM
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
     orm_adapter (0.5.0)
+    pagy (6.0.3)
     parallel (1.22.1)
     parser (3.1.2.0)
       ast (~> 2.4.1)
@@ -400,6 +401,7 @@ DEPENDENCIES
   jwt
   listen
   meilisearch-rails
+  pagy
   pg (>= 0.18, < 2.0)
   pg_search
   puma (~> 5.6)

--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -2,10 +2,29 @@
 
 class Api::V1::ArticlesController < APIApplicationController
   def index
-    render json: { data: Article.active.order('video_of_the_day DESC, id DESC').all }, status: :ok
+    page_size = Addressable::URI.parse(request.url).query_values["page_size"]
+
+    Pagy::DEFAULT[:items] = page_size || 25
+    @pagy, @articles = pagy(Article.active.order('video_of_the_day DESC, id DESC').all)
+
+    render json: { data: @articles, pagination_metadata: get_pagy_metadata(@pagy, page_size) }, status: :ok
   end
 
   def show
     render json: { data: Article.find(params[:id]) }, status: :ok
+  end
+
+  private
+
+  def get_pagy_metadata(metadata, page_size)
+    {
+      count: metadata.count,
+      page: metadata.page,
+      pages: metadata.pages,
+      next: metadata.next,
+      prev: metadata.prev,
+      next_url: api_v1_articles_url(page_size: page_size, page: metadata.next),
+      prev_url: api_v1_articles_url(page_size: page_size, page: metadata.prev)
+    }
   end
 end

--- a/app/controllers/api/v2/campaign_actions_controller.rb
+++ b/app/controllers/api/v2/campaign_actions_controller.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-include Pagy::Backend
 include ::V2::Progress::UserProgress
 
 class Api::V2::CampaignActionsController < APIApplicationController

--- a/app/controllers/api/v2/campaign_actions_controller.rb
+++ b/app/controllers/api/v2/campaign_actions_controller.rb
@@ -11,7 +11,7 @@ class Api::V2::CampaignActionsController < APIApplicationController
     Pagy::DEFAULT[:items] = page_size || 25
     @pagy, @campaign_actions = pagy(CampaignAction.all)
 
-    render json: { data: actions_data(@campaign_actions), pagination_metadata: get_pagy_metadata(@pagy) }, status: :ok
+    render json: { data: actions_data(@campaign_actions), pagination_metadata: get_pagy_metadata(@pagy, page_size) }, status: :ok
   end
 
   def show
@@ -20,8 +20,8 @@ class Api::V2::CampaignActionsController < APIApplicationController
 
 private
 
-  def actions_data(paginated_campaign_actions_data)
-    ::V2::Filters::Filter.new(request: request, filter_model: ::V2::Filters::CampaignActionFilter, data: paginated_campaign_actions_data).call.map do |campaign|
+  def actions_data(data)
+    ::V2::Filters::Filter.new(request: request, filter_model: ::V2::Filters::CampaignActionFilter, data: data).call.map do |campaign|
       merge_additional_fields(campaign)
     end
   end
@@ -54,8 +54,8 @@ private
       pages: metadata.pages,
       next: metadata.next,
       prev: metadata.prev,
-      next_url: api_v2_actions_url(page: metadata.next),
-      prev_url: api_v2_actions_url(page: metadata.prev)
+      next_url: api_v2_actions_url(page_size: page_size, page: metadata.next),
+      prev_url: api_v2_actions_url(page_size: page_size, page: metadata.prev)
     }
   end
 end

--- a/app/controllers/api/v2/campaigns_controller.rb
+++ b/app/controllers/api/v2/campaigns_controller.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-include Pagy::Backend
 include ::V2::Progress::UserProgress
 
 class Api::V2::CampaignsController < APIApplicationController

--- a/app/controllers/api/v2/learning_resources_controller.rb
+++ b/app/controllers/api/v2/learning_resources_controller.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-include Pagy::Backend
 include ::V2::Progress::UserProgress
 
 class Api::V2::LearningResourcesController < APIApplicationController

--- a/app/controllers/api/v2/learning_resources_controller.rb
+++ b/app/controllers/api/v2/learning_resources_controller.rb
@@ -1,11 +1,17 @@
 # frozen_string_literal: true
+include Pagy::Backend
 include ::V2::Progress::UserProgress
 
 class Api::V2::LearningResourcesController < APIApplicationController
   rescue_from JSON::ParserError, with: :invalid_json_message
 
   def index
-    render json: { data: learning_resources_data }, status: :ok
+    page_size = Addressable::URI.parse(request.url).query_values["page_size"]
+
+    Pagy::DEFAULT[:items] = page_size || 25
+    @pagy, @learning_resources = pagy(LearningResource.all)
+
+    render json: { data: learning_resources_data(@learning_resources), pagination_metadata: get_pagy_metadata(@pagy, page_size) }, status: :ok
   end
 
   def show
@@ -14,8 +20,8 @@ class Api::V2::LearningResourcesController < APIApplicationController
 
 private
 
-  def learning_resources_data
-    ::V2::Filters::Filter.new(request: request, filter_model: ::V2::Filters::LearningResourceFilter, data: LearningResource.all).call.map do |learning_resource|
+  def learning_resources_data(data)
+    ::V2::Filters::Filter.new(request: request, filter_model: ::V2::Filters::LearningResourceFilter, data: data).call.map do |learning_resource|
       merge_additional_fields(learning_resource)
     end
   end
@@ -39,5 +45,17 @@ private
     LearningResource.find(learning_resource_id)&.causes.map do |lrc|
       lrc.serializable_hash.symbolize_keys.merge({joined: get_status(lrc.id, request)})
     end
+  end
+
+  def get_pagy_metadata(metadata, page_size)
+    {
+      count: metadata.count,
+      page: metadata.page,
+      pages: metadata.pages,
+      next: metadata.next,
+      prev: metadata.prev,
+      next_url: api_v2_learning_resources_url(page_size: page_size, page: metadata.next),
+      prev_url: api_v2_learning_resources_url(page_size: page_size, page: metadata.prev)
+    }
   end
 end

--- a/app/controllers/api_application_controller.rb
+++ b/app/controllers/api_application_controller.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+include Pagy::Backend
 
 class APIApplicationController < ActionController::API
   rescue_from ActiveRecord::RecordNotFound, with: :record_not_found

--- a/app/services/v2/filters/filter.rb
+++ b/app/services/v2/filters/filter.rb
@@ -6,7 +6,7 @@ module V2
       attr_reader :filter_model
 
       def initialize(request:, filter_model:, data:)
-        @query_params = Addressable::URI.parse(request.url).query_values
+        @query_params = Addressable::URI.parse(request.url).query_values.except("page_size", "page")
         @filter_model = filter_model
         @data = data
         @user = User.get_user_from_request(request)

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -393,7 +393,7 @@ ActiveRecord::Schema.define(version: 2023_03_28_194251) do
     t.text "description"
     t.boolean "newsletter", default: false
     t.integer "user_role_id"
-    t.string "auth_user_id", null: false
+    t.string "auth_user_id", default: "-", null: false
     t.index ["auth_user_id"], name: "index_users_on_auth_user_id"
   end
 

--- a/spec/requests/api/v2/campaign_actions_request_spec.rb
+++ b/spec/requests/api/v2/campaign_actions_request_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Api::V2::CampaignActionsController, type: :request do
       tags 'API::V2(latest) -> Actions'
       produces 'application/json'
       let(:'Authorization') { create_jwt_header(user) }
-      
+
       response '200', 'Campaign actions found' do
         schema type: :object,
         properties: campaign_action_schema
@@ -40,7 +40,7 @@ RSpec.describe Api::V2::CampaignActionsController, type: :request do
     get "If no user token header present, completed: 'User not authenticated'" do
       tags 'API::V2(latest) -> Actions'
       produces 'application/json'
-      
+
       response '200', 'Campaign Actions found!' do
         schema type: :object,
         properties: campaign_action_schema
@@ -61,7 +61,7 @@ RSpec.describe Api::V2::CampaignActionsController, type: :request do
     get "Filters campaign actions by cause id's" do
       tags 'API::V2(latest) -> Actions'
       produces 'application/json'
-      
+
       let(:cause_id) { '1' }
       response '200', 'Actions found!' do
         schema type: :object,
@@ -86,7 +86,7 @@ RSpec.describe Api::V2::CampaignActionsController, type: :request do
     get "Filters campaign actions by cause id's" do
       tags 'API::V2(latest) -> Actions'
       produces 'application/json'
-      
+
       response '200', 'Campaign Action found!' do
         schema type: :object,
         properties: campaign_action_schema
@@ -114,7 +114,7 @@ RSpec.describe Api::V2::CampaignActionsController, type: :request do
       produces 'application/json'
       parameter name: :id, in: :path, type: :string
       let(:'Authorization') { create_jwt_header(user) }
-      
+
       response '200', 'Campaign Action found! (with user header)' do
         schema type: :object,
         properties: campaign_action_schema
@@ -127,6 +127,33 @@ RSpec.describe Api::V2::CampaignActionsController, type: :request do
 
         it 'returns a valid 200 response' do |example|
           assert_response_matches_metadata(example.metadata)
+        end
+      end
+    end
+  end
+
+  context "pagination" do
+    path '/api/v2/actions?page_size=1' do
+      get 'Pagination' do
+        tags 'API::V2(latest) -> Actions'
+        produces 'application/json'
+        parameter name: :id, in: :path, type: :string
+        let(:'Authorization') { create_jwt_header(user) }
+
+        response '200', 'Campaign Actions returned with Pagination Metadata' do
+          schema type: :object,
+          properties: campaign_action_schema
+          parameter name: 'Authorization', :in => :header, :type => :string
+
+          before do |example|
+            campaign_action
+            submit_request(example.metadata)
+          end
+
+          it 'returns a valid 200 response' do |example|
+            assert_response_matches_metadata(example.metadata)
+            p example.metadata
+          end
         end
       end
     end


### PR DESCRIPTION
this adds pagy gem to the mix with pagination onto the following endpoints: 

v2 learning resources
v2 campaigns
v2 campaign actions
v1 articles

you can add custom page size using the `page_size={your_custom}` to the query params

default page size if it is not specified will be 25

metadata about next and prev urls are stored in the json object named `pagination_metadata` that can be found in the response

example response

```json
{
    "data": [
        {
            "id": 1,
            "title": "rubber meets the road",
            "time": 0.1,
            "link": "http://waters.net/nathan.jacobson",
            "type": "",
            "learning_topic_id": 1,
            "created_at": "2022-08-09T08:55:51.094Z",
            "updated_at": "2022-08-09T08:55:51.094Z",
            "source": "",
            "release_date": "2022-03-19T00:00:00.000Z",
            "end_date": "2022-09-26T00:00:00.000Z",
            "causes": [
                {
                    "id": 32,
                    "image": "http://homenick-schultz.org/lilliam",
                    "icon": "http://goodwin-pfeffer.biz/krystal.corkery",
                    "name": "thought leader",
                    "description": "Vel aperiam sint quod.",
                    "joiners": 4,
                    "created_at": "2022-08-09T08:55:51.104Z",
                    "updated_at": "2022-08-09T08:55:51.104Z",
                    "joined": false
                }
            ],
            "completed": false
        },
        {
            "id": 2,
            "title": "agile marketing",
            "time": 0.1,
            "link": "http://daniel-senger.name/ginger.jakubowski",
            "type": "",
            "learning_topic_id": 2,
            "created_at": "2022-08-09T08:55:51.127Z",
            "updated_at": "2022-08-09T08:55:51.127Z",
            "source": "",
            "release_date": "2022-04-09T00:00:00.000Z",
            "end_date": "2022-11-28T00:00:00.000Z",
            "causes": [
                {
                    "id": 34,
                    "image": "http://moen.org/hal.mohr",
                    "icon": "http://bartoletti-crist.net/franklyn_green",
                    "name": "bandwidth-constrained",
                    "description": "Expedita exercitationem accusamus quia.",
                    "joiners": 83,
                    "created_at": "2022-08-09T08:55:51.133Z",
                    "updated_at": "2022-08-09T08:55:51.133Z",
                    "joined": false
                }
            ],
            "completed": false
        }
    ],
    "pagination_metadata": {
        "count": 5,
        "page": 1,
        "pages": 3,
        "next": 2,
        "prev": null,
        "next_url": "http://localhost:3000/api/v2/learning_resources?page=2&page_size=2",
        "prev_url": "http://localhost:3000/api/v2/learning_resources?page_size=2"
    }
}
```